### PR TITLE
Load updated changes to repo

### DIFF
--- a/projects/picker/src/lib/date-time/calendar-month-view.component.html
+++ b/projects/picker/src/lib/date-time/calendar-month-view.component.html
@@ -21,7 +21,7 @@
            (select)="selectCalendarCell($event)">
     </tbody>
 </table>
-<div class="month-buttons">
+<div class="month-buttons" *ngIf="showMonth">
     <button class="owl-dt-control-button default cancel" (click) = "cancel($event)">
         Cancel
     </button>

--- a/projects/picker/src/lib/date-time/calendar-month-view.component.ts
+++ b/projects/picker/src/lib/date-time/calendar-month-view.component.ts
@@ -241,6 +241,12 @@ export class OwlMonthViewComponent<T>
         );
     }
 
+    /**
+     * Boolean flag for hiding 'Set Date' / 'Cancel' duo 
+     **/
+    @Input()
+    showMonth: boolean;
+
     private firstDateOfMonth: T;
 
     private localeSub: Subscription = Subscription.EMPTY;
@@ -337,15 +343,25 @@ export class OwlMonthViewComponent<T>
      * Handle a new date selected
      */
     selectDate(date: number): void {
+        let selected;
+
         if (date) {
             const daysDiff = date - 1;
-            const selected = this.dateTimeAdapter.addCalendarDays(
+            selected = this.dateTimeAdapter.addCalendarDays(
                 this.firstDateOfMonth,
                 daysDiff
             );
     
             this.selectedChange.emit(selected);
             this.userSelection.emit();
+        }
+        else {
+            // Set to today's date
+            selected = this.dateTimeAdapter.addCalendarDays(
+                this.firstDateOfMonth,
+                new Date().getDate() - 1
+            );
+            this.selectedChange.emit(selected);
         }
     }
 

--- a/projects/picker/src/lib/date-time/calendar.component.html
+++ b/projects/picker/src/lib/date-time/calendar.component.html
@@ -73,6 +73,7 @@
             [selectMode]="selectMode"
             [minDate]="minDate"
             [maxDate]="maxDate"
+            [showMonth]="showMonth"
             [dateFilter]="dateFilter"
             [hideOtherMonths]="hideOtherMonths"
             (pickerMomentChange)="handlePickerMomentChange($event)"

--- a/projects/picker/src/lib/date-time/calendar.component.ts
+++ b/projects/picker/src/lib/date-time/calendar.component.ts
@@ -25,7 +25,6 @@ import {
     OwlDateTimeFormats
 } from './adapter/date-time-format.class';
 import { SelectMode } from './date-time.class';
-import { take } from 'rxjs/operators';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -142,9 +141,15 @@ export class OwlCalendarComponent<T>
 
     /**
      * Whether to hide dates in other months at the start or end of the current month.
-     * */
+     **/
     @Input()
     hideOtherMonths: boolean;
+
+    /**
+     * If both calendar and timer shown, hide the 'Set Date' buttons
+     **/
+    @Input() 
+    showMonth: boolean;
 
     /** Emits when the currently picker moment changes. */
     @Output()

--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.html
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.html
@@ -14,6 +14,7 @@
             [maxDate]="picker.maxDateTime"
             [dateFilter]="picker.dateTimeFilter"
             [startView]="picker.startView"
+            [showMonth]="pickerType === 'calendar'"
             [hideOtherMonths]="picker.hideOtherMonths"
             (yearSelected)="picker.selectYear($event)"
             (monthSelected)="picker.selectMonth($event)"

--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.scss
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.scss
@@ -1,0 +1,7 @@
+@media only screen and (max-height: 400px) {
+    :host {
+        height: 300px;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+}

--- a/projects/picker/src/lib/date-time/timer.component.html
+++ b/projects/picker/src/lib/date-time/timer.component.html
@@ -31,6 +31,6 @@
         (valueChange)="setSecondValue($event)"></owl-date-time-timer-box> -->
 
 <div *ngIf="hour12Timer" class="owl-dt-timer-hour12">
-        <div class="owl-dt-timer-ampm-trigger" [ngStyle]="{ 'color': !isPM ? 'black' : 'gray' }" (click)="isPM = false; setMeridiem($event)">AM</div>
-        <div class="owl-dt-timer-ampm-trigger" [ngStyle]="{ 'color': isPM ? 'black' : 'gray' }" (click)="isPM = true; setMeridiem($event)">PM</div>
+        <div class="owl-dt-timer-ampm-trigger" [ngStyle]="{ 'color': !isPM ? 'black' : 'gray' }" (click)="isPM = false; setMeridiem($event)">am</div>
+        <div class="owl-dt-timer-ampm-trigger" [ngStyle]="{ 'color': isPM ? 'black' : 'gray' }" (click)="isPM = true; setMeridiem($event)">pm</div>
 </div>

--- a/projects/picker/src/sass/picker.scss
+++ b/projects/picker/src/sass/picker.scss
@@ -320,8 +320,8 @@ $theme-color: #3f51b5;
   :not(.owl-dt-calendar-cell-disabled):hover > .owl-dt-calendar-cell-content:not(.owl-dt-calendar-cell-selected) {
 
     &:not(.owl-dt-calendar-cell-today) {
-      background-color: #538ec0;
-      color: #ffffff;
+      background-color: #f5f5f5;
+      color: black;
     }
   }
 
@@ -377,6 +377,7 @@ $theme-color: #3f51b5;
     outline: medium none;
     font-size: 1.2em;
     padding: .2em;
+    -webkit-appearance: none;
   }
 }
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,21 @@
-<label for="daterange">Datetime range (click, then press 'Set' to modify):</label>
-<input [(ngModel)]="selectedMoments" [selectMode]="'range'"
+<label for="daterange">Date range (click, then press 'Set' to modify):</label>
+<input
        [owlDateTimeTrigger]="date_range_component" [owlDateTime]="date_range_component"
        style="width: 100%; color: cornflowerblue"
        id="daterange" matInput>
-<owl-date-time #date_range_component></owl-date-time>
+<owl-date-time #date_range_component [pickerType]="'calendar'"></owl-date-time>
+
+<label for="timerange">Time range (click, then press 'Set' to modify):</label>
+<input
+       [owlDateTimeTrigger]="time_component" [owlDateTime]="time_component"
+       style="width: 100%; color: cornflowerblue"
+       id="timerange" matInput>
+<owl-date-time #time_component [pickerType]="'timer'" [hour12Timer]="true"></owl-date-time>
+
+<label for="both">Both: </label>
+<input
+       [owlDateTimeTrigger]="both_componnet" [owlDateTime]="both_componnet"
+       style="width: 100%; color: cornflowerblue" 
+       id="both" matInput>
+<owl-date-time #both_componnet [pickerType]="'both'"></owl-date-time>
+

--- a/src/index.html
+++ b/src/index.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <title>DateTimePickerApp</title>
-  <base href="/">
-
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8" />
+  <title>Cetaris Vendor</title>
+  <base href="./" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>


### PR DESCRIPTION
PBIs that will be referenced in this pull request include: 

#138276: Click the calendar (they already have date selected). Without changing to any dates, just click Select Date. Calendar doesn't close.

#138277: Two dates can be selected

#138283: For time picker user can type within the time field. For mobiles (with smaller screens) when clicked within the field to type, keyboard overlaps the time fields and they are not seen.

#138361

#138837: Show only two buttons not 4

#138840: There is additional grey border width around the time boxes

#138841: Lowercase am and pm